### PR TITLE
Reverse the ep_spellcheck_default option behaviour

### DIFF
--- a/spellcheck.js
+++ b/spellcheck.js
@@ -3,7 +3,7 @@ var settings = require('ep_etherpad-lite/node/utils/Settings');
 var checked_state = '';
 
 exports.eejsBlock_mySettings = function (hook_name, args, cb) {
-  if (!settings.ep_spellcheck_default) checked_state = 'checked';
+  if (settings.ep_spellcheck_default) checked_state = 'checked';
   args.content = args.content + eejs.require('ep_spellcheck/templates/spellcheck_entry.ejs', {checked : checked_state});
   return cb();
 }


### PR DESCRIPTION
Add "ep_spellcheck_default": true in settings.json to enable by default
