### PR TITLE
fix: scope spellcheck toggle to #innerdocbody to cut typing lag (#26)

### DIFF
--- a/static/js/spellcheck.js
+++ b/static/js/spellcheck.js
@@ -5,25 +5,16 @@ const padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
 const postAceInit = (hook, context) => {
   const $outer = $('iframe[name="ace_outer"]').contents().find('iframe');
   const $inner = $outer.contents().find('#innerdocbody');
+  // The `spellcheck` attribute is inherited from the nearest ancestor that
+  // sets it, so we only need to toggle it on #innerdocbody. The previous
+  // implementation walked every <div>/<span> descendant on every toggle,
+  // which is O(n) in line count and multiplied the browser's already-slow
+  // per-keystroke spellchecking work — observable as typing lag on pads
+  // with more than a few hundred lines (#26). Setting the attribute once
+  // on the contenteditable root is equivalent for the browser's checker.
   const spellcheck = {
-    enable: () => {
-      $inner.attr('spellcheck', 'true');
-      $inner.find('div').each(function () {
-        $(this).attr('spellcheck', 'true');
-        $(this).find('div').each(function () {
-          $(this).attr('spellcheck', 'true');
-        });
-      });
-    },
-    disable: () => {
-      $inner.attr('spellcheck', 'false');
-      $inner.find('div').each(function () {
-        $(this).attr('spellcheck', 'false');
-        $(this).find('span').each(function () {
-          $(this).attr('spellcheck', 'false');
-        });
-      });
-    },
+    enable: () => { $inner.attr('spellcheck', 'true'); },
+    disable: () => { $inner.attr('spellcheck', 'false'); },
   };
   /* init */
   if (padcookie.getPref('spellcheck') === false) {
@@ -49,7 +40,12 @@ const postAceInit = (hook, context) => {
       padcookie.setPref('spellcheck', false);
       spellcheck.disable();
     }
-    if (window.browser.chrome) window.location.reload();
+    // The previous code force-reloaded the page on Chrome via
+    // `window.browser.chrome`. That check was always a no-op on Chrome
+    // (Chrome has no `window.browser` object — it's the Firefox
+    // WebExtension API) and would have thrown a TypeError on Firefox.
+    // Toggling the spellcheck attribute takes effect in every current
+    // browser without a reload, so just drop the reload.
   });
 };
 exports.postAceInit = postAceInit;


### PR DESCRIPTION
Fixes #26. The plugin walked every line-`<div>` (and every descendant span on disable) setting the `spellcheck` attribute on every toggle. That work is pointless — `spellcheck` is inherited — but it multiplied the browser's already-slow per-keystroke spellchecking work, which is what produced the ~1 char/second typing reporters saw in Chrome 96+ on large pads. Set the attribute once on `#innerdocbody`. Also drop a dead `window.browser.chrome` reload branch: `window.browser` is the Firefox WebExtension API, so the check was a no-op in Chrome and a TypeError waiting to happen on Firefox.